### PR TITLE
Fix empty list crash in page range helper

### DIFF
--- a/booktoki-all_v4.py
+++ b/booktoki-all_v4.py
@@ -68,6 +68,9 @@ def compact_ranges(nums: List[int]) -> List[Union[int, List[int]]]:
         >>> compact_ranges([1, 2, 3, 7, 9, 10, 11, 20])
         [[1, 3], 7, [9, 11], 20]
     """
+    if not nums:
+        return []
+
     nums.sort()
     result: List[Union[int, List[int]]] = []
     start = prev = nums[0]

--- a/booktoki-all_v4a.py
+++ b/booktoki-all_v4a.py
@@ -69,6 +69,9 @@ def compact_ranges(nums: List[int]) -> List[Union[int, List[int]]]:
         >>> compact_ranges([1, 2, 3, 7, 9, 10, 11, 20])
         [[1, 3], 7, [9, 11], 20]
     """
+    if not nums:
+        return []
+
     nums.sort()
     result: List[Union[int, List[int]]] = []
     start = prev = nums[0]


### PR DESCRIPTION
## Summary
- avoid `IndexError` in `compact_ranges` when given an empty list

## Testing
- `python -m py_compile booktoki-all_v4.py booktoki-all_v4a.py`
- `python -m py_compile "[AllInOne] booktoki_v3.py" booktoki.py`

------
https://chatgpt.com/codex/tasks/task_e_684044125f848320a6587503939c001d