### PR TITLE
Replace repo links with hyriph

### DIFF
--- a/[AllInOne] booktoki_v3.py
+++ b/[AllInOne] booktoki_v3.py
@@ -1,6 +1,6 @@
 # coding: utf8
 # title: Add Booktoki.com
-# author: github.com/STR-HK/hdl-stubs
+# author: github.com/hyriph/hdl-stubs
 # comment: Created at 2023/10/23
 
 from io import BytesIO

--- a/blacktoon_v3.hds
+++ b/blacktoon_v3.hds
@@ -1,24 +1,24 @@
 """
 이 스크립트는 더 이상 기능하지 않습니다.
-https://github.com/STR-HK/hdl-stubs/ 에서 최신 버전의 스크립트를 다운로드하세요.
+https://github.com/hyriph/hdl-stubs/ 에서 최신 버전의 스크립트를 다운로드하세요.
 
 This script is no longer functional.
-Please download the latest version of the script from https://github.com/STR-HK/hdl-stubs/
+Please download the latest version of the script from https://github.com/hyriph/hdl-stubs/
 
 このスクリプトはもう機能しません。
-最新バージョンのスクリプトを https://github.com/STR-HK/hdl-stubs/ からダウンロードしてください。
+最新バージョンのスクリプトを https://github.com/hyriph/hdl-stubs/ からダウンロードしてください。
 
 此脚本已不再可用。
-请从 https://github.com/STR-HK/hdl-stubs/ 下载最新版本的脚本。
+请从 https://github.com/hyriph/hdl-stubs/ 下载最新版本的脚本。
 
 Este script ya no funciona.
-Por favor, descarga la última versión del script desde https://github.com/STR-HK/hdl-stubs/.
+Por favor, descarga la última versión del script desde https://github.com/hyriph/hdl-stubs/.
 
 Ce script n'est plus fonctionnel.
-Veuillez télécharger la dernière version du script depuis https://github.com/STR-HK/hdl-stubs/.
+Veuillez télécharger la dernière version du script depuis https://github.com/hyriph/hdl-stubs/.
 
 Этот скрипт больше не работает.
-Пожалуйста, скачайте последнюю версию скрипта с https://github.com/STR-HK/hdl-stubs/.
+Пожалуйста, скачайте последнюю версию скрипта с https://github.com/hyriph/hdl-stubs/.
 """
 
 #coding: utf8

--- a/booktoki.hds
+++ b/booktoki.hds
@@ -1,29 +1,29 @@
 """
 이 스크립트는 더 이상 기능하지 않습니다.
-https://github.com/STR-HK/hdl-stubs/ 에서 최신 버전의 스크립트를 다운로드하세요.
+https://github.com/hyriph/hdl-stubs/ 에서 최신 버전의 스크립트를 다운로드하세요.
 
 This script is no longer functional.
-Please download the latest version of the script from https://github.com/STR-HK/hdl-stubs/
+Please download the latest version of the script from https://github.com/hyriph/hdl-stubs/
 
 このスクリプトはもう機能しません。
-最新バージョンのスクリプトを https://github.com/STR-HK/hdl-stubs/ からダウンロードしてください。
+最新バージョンのスクリプトを https://github.com/hyriph/hdl-stubs/ からダウンロードしてください。
 
 此脚本已不再可用。
-请从 https://github.com/STR-HK/hdl-stubs/ 下载最新版本的脚本。
+请从 https://github.com/hyriph/hdl-stubs/ 下载最新版本的脚本。
 
 Este script ya no funciona.
-Por favor, descarga la última versión del script desde https://github.com/STR-HK/hdl-stubs/.
+Por favor, descarga la última versión del script desde https://github.com/hyriph/hdl-stubs/.
 
 Ce script n'est plus fonctionnel.
-Veuillez télécharger la dernière version du script depuis https://github.com/STR-HK/hdl-stubs/.
+Veuillez télécharger la dernière version du script depuis https://github.com/hyriph/hdl-stubs/.
 
 Этот скрипт больше не работает.
-Пожалуйста, скачайте последнюю версию скрипта с https://github.com/STR-HK/hdl-stubs/.
+Пожалуйста, скачайте последнюю версию скрипта с https://github.com/hyriph/hdl-stubs/.
 """
 
 # coding: utf8
 # title: Add Booktoki.com
-# author: github.com/STR-HK/hdl-stubs
+# author: github.com/hyriph/hdl-stubs
 # comment: Created at 12022/09/17
 
 from fileinput import filename

--- a/booktoki.py
+++ b/booktoki.py
@@ -1,30 +1,30 @@
 """
 이 스크립트는 더 이상 기능하지 않습니다.
-https://github.com/STR-HK/hdl-stubs/ 에서 최신 버전의 스크립트를 다운로드하세요.
+https://github.com/hyriph/hdl-stubs/ 에서 최신 버전의 스크립트를 다운로드하세요.
 
 This script is no longer functional.
-Please download the latest version of the script from https://github.com/STR-HK/hdl-stubs/
+Please download the latest version of the script from https://github.com/hyriph/hdl-stubs/
 
 このスクリプトはもう機能しません。
-最新バージョンのスクリプトを https://github.com/STR-HK/hdl-stubs/ からダウンロードしてください。
+最新バージョンのスクリプトを https://github.com/hyriph/hdl-stubs/ からダウンロードしてください。
 
 此脚本已不再可用。
-请从 https://github.com/STR-HK/hdl-stubs/ 下载最新版本的脚本。
+请从 https://github.com/hyriph/hdl-stubs/ 下载最新版本的脚本。
 
 Este script ya no funciona.
-Por favor, descarga la última versión del script desde https://github.com/STR-HK/hdl-stubs/.
+Por favor, descarga la última versión del script desde https://github.com/hyriph/hdl-stubs/.
 
 Ce script n'est plus fonctionnel.
-Veuillez télécharger la dernière version du script depuis https://github.com/STR-HK/hdl-stubs/.
+Veuillez télécharger la dernière version du script depuis https://github.com/hyriph/hdl-stubs/.
 
 Этот скрипт больше не работает.
-Пожалуйста, скачайте последнюю версию скрипта с https://github.com/STR-HK/hdl-stubs/.
+Пожалуйста, скачайте последнюю версию скрипта с https://github.com/hyriph/hdl-stubs/.
 """
 
 
 # coding: utf8
 # title: Add Booktoki.com
-# author: github.com/STR-HK/hdl-stubs
+# author: github.com/hyriph/hdl-stubs
 # comment: Created at 12022/09/17
 
 from fileinput import filename

--- a/booktoki_v2.hds
+++ b/booktoki_v2.hds
@@ -1,29 +1,29 @@
 """
 이 스크립트는 더 이상 기능하지 않습니다.
-https://github.com/STR-HK/hdl-stubs/ 에서 최신 버전의 스크립트를 다운로드하세요.
+https://github.com/hyriph/hdl-stubs/ 에서 최신 버전의 스크립트를 다운로드하세요.
 
 This script is no longer functional.
-Please download the latest version of the script from https://github.com/STR-HK/hdl-stubs/
+Please download the latest version of the script from https://github.com/hyriph/hdl-stubs/
 
 このスクリプトはもう機能しません。
-最新バージョンのスクリプトを https://github.com/STR-HK/hdl-stubs/ からダウンロードしてください。
+最新バージョンのスクリプトを https://github.com/hyriph/hdl-stubs/ からダウンロードしてください。
 
 此脚本已不再可用。
-请从 https://github.com/STR-HK/hdl-stubs/ 下载最新版本的脚本。
+请从 https://github.com/hyriph/hdl-stubs/ 下载最新版本的脚本。
 
 Este script ya no funciona.
-Por favor, descarga la última versión del script desde https://github.com/STR-HK/hdl-stubs/.
+Por favor, descarga la última versión del script desde https://github.com/hyriph/hdl-stubs/.
 
 Ce script n'est plus fonctionnel.
-Veuillez télécharger la dernière version du script depuis https://github.com/STR-HK/hdl-stubs/.
+Veuillez télécharger la dernière version du script depuis https://github.com/hyriph/hdl-stubs/.
 
 Этот скрипт больше не работает.
-Пожалуйста, скачайте последнюю версию скрипта с https://github.com/STR-HK/hdl-stubs/.
+Пожалуйста, скачайте последнюю версию скрипта с https://github.com/hyriph/hdl-stubs/.
 """
 
 # coding: utf8
 # title: Add Booktoki.com
-# author: github.com/STR-HK/hdl-stubs
+# author: github.com/hyriph/hdl-stubs
 # comment: Created at 12022/12/10
 
 from io import BytesIO


### PR DESCRIPTION
## Summary
- update repo references to `hyriph/hdl-stubs`
- update author line in `[AllInOne] booktoki_v3.py`

## Testing
- `python -m py_compile booktoki.py '[AllInOne] booktoki_v3.py'`
- `python -m py_compile booktoki.hds booktoki_v2.hds blacktoon_v3.hds blacktoon_v4.hds freader.hds hentaishark.hds mananumber.hds`

------
https://chatgpt.com/codex/tasks/task_e_684048c0c1948320a6657e0364dc4fe4